### PR TITLE
Fix Title Box

### DIFF
--- a/Activity_1_Webapp/styles.css
+++ b/Activity_1_Webapp/styles.css
@@ -29,6 +29,7 @@ body,
   font-family: Arial, sans-serif;
   font-weight: bold;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  max-width: 600px
 }
 
 .link-box {

--- a/Activity_2_Webapp/styles.css
+++ b/Activity_2_Webapp/styles.css
@@ -29,6 +29,7 @@ body,
   font-family: Arial, sans-serif;
   font-weight: bold;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  max-width: 600px
 }
 
 .link-box {


### PR DESCRIPTION
The title box was too wide and interfered with the editor. I changed the styles to add a maximum width for the textbox so this shouldn't be an issue anymore, at least on fairly large screens